### PR TITLE
refactor: Display message when there is no data to show on the chart

### DIFF
--- a/components/graphs/OverviewChart.tsx
+++ b/components/graphs/OverviewChart.tsx
@@ -95,7 +95,14 @@ function	OverviewChart(props: TOverviewChartProps): ReactElement {
 	return (
 		<div className={'h-[400px]'}>
 
-			{harvestEvents[0].name !== 'no data' && (
+			{harvestEvents[0].name !== 'no data' ? (
+				<div className={'flex h-full w-[85%] items-center justify-center bg-[#E1E1E1]'}>
+					<div className={'text-center'}>
+						<h1>{'Nothing to see here...'}</h1>
+						<p>{'Try adjusting the range or viewing another asset'}</p>
+					</div>
+				</div>
+			) : (
 				<Chart
 					title={'Individual Harvest Events (USD)'}
 					type={'stacked'}

--- a/components/graphs/OverviewChart.tsx
+++ b/components/graphs/OverviewChart.tsx
@@ -95,11 +95,11 @@ function	OverviewChart(props: TOverviewChartProps): ReactElement {
 	return (
 		<div className={'h-[400px]'}>
 
-			{harvestEvents[0].name !== 'no data' ? (
+			{harvestEvents[0].name === 'no data' ? (
 				<div className={'flex h-full w-[85%] items-center justify-center bg-[#E1E1E1]'}>
 					<div className={'text-center'}>
-						<h1>{'Nothing to see here...'}</h1>
-						<p>{'Try adjusting the range or viewing another asset'}</p>
+						<h1 className={'mb-2'}>{'Nothing to see here...'}</h1>
+						<p>{'Your vaults haven\'t earned any payouts yet. Check back later!'}</p>
 					</div>
 				</div>
 			) : (


### PR DESCRIPTION
## Description

A message is included in the Overview tab that will be displayed conditionally when there is no data for the harvest events chart. Previously it was only showing an empty graph.

## Motivation and Context

Improve the experience of the partners and the appearance of the page. It's better showing a message when there is no relevant data, an empty graphic could be read as an error.

## How Has This Been Tested?

After making the changes I ran `yarn dev` and confirmed that everything appeared as expected