### PR TITLE
refactor: Add error message in Login validation

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -190,7 +190,7 @@ function	AppHeader(): ReactElement {
 									if (!isMatched){
 										toast({
 											type: 'warning',
-											content: 'That address isn\'t associated with any dashboard. Contact support if you believe this is a mistake.',
+											content: 'That address isn\'t associated with any dashboard. Reach out to us if you believe this is a mistake.',
 											duration: 10000
 										});
 									}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -9,6 +9,7 @@ import {PARTNERS} from 'utils/b2b/Partners';
 import {Button} from '@yearn-finance/web-lib/components/Button';
 import {Card} from '@yearn-finance/web-lib/components/Card';
 import {Modal} from '@yearn-finance/web-lib/components/Modal';
+import {yToast} from '@yearn-finance/web-lib/components/yToast';
 import {WithYearn} from '@yearn-finance/web-lib/contexts/WithYearn';
 import {toAddress} from '@yearn-finance/web-lib/utils/address';
 
@@ -166,8 +167,12 @@ function	AppHeader(): ReactElement {
 								onSave={(addr): void => {
 									const address = toAddress(addr);
 
+									const {toast} = yToast();
+									let isMatched = false;
+
 									Object.values(PARTNERS).forEach((partner): void => {
 										if (partner.treasury?.includes(address)) {
+											isMatched = true;
 											const idx = partner.treasury?.indexOf(address);
 
 											console.log(partner.treasury[idx]);
@@ -182,6 +187,14 @@ function	AppHeader(): ReactElement {
 											});
 										}
 									});
+
+									if (!isMatched){
+										toast({
+											type: 'error',
+											content: 'Invalid partner address',
+											duration: 3000
+										});
+									}
 
 								} } />
 						</>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -93,6 +93,7 @@ function	AppHead(): ReactElement {
 
 function	AppHeader(): ReactElement {
 	const	router = useRouter();
+	const {toast} = yToast();
 	const	{hasModal, isLoggedIn, isLoading, set_hasModal, set_isLoggedIn, set_isLoading} = useAuth();
 	const	[authOption, set_authOption] = useState('Log in');
 	const	[address, set_address] = useState('');
@@ -166,8 +167,6 @@ function	AppHeader(): ReactElement {
 								initialValue={''}
 								onSave={(addr): void => {
 									const address = toAddress(addr);
-
-									const {toast} = yToast();
 									let isMatched = false;
 
 									Object.values(PARTNERS).forEach((partner): void => {
@@ -190,9 +189,9 @@ function	AppHeader(): ReactElement {
 
 									if (!isMatched){
 										toast({
-											type: 'error',
-											content: 'Invalid partner address',
-											duration: 3000
+											type: 'warning',
+											content: 'That address isn\'t associated with any dashboard. Contact support if you believe this is a mistake.',
+											duration: 10000
 										});
 									}
 


### PR DESCRIPTION
## Description

Include the error message with the help of the yToast component of Web-lib, when an invalid partner address is added in the login.

## Motivation and Context

Show an alert message to the user when the address provided in the login is not matching the approved addresses.

## How Has This Been Tested?

After making the changes I ran `yarn dev` and confirmed that everything appeared as expected