### PR TITLE
fix: Resolve type warning

### DIFF
--- a/pages/dashboard/[partnerID].tsx
+++ b/pages/dashboard/[partnerID].tsx
@@ -158,7 +158,7 @@ export async function getStaticPaths(): Promise<GetStaticPathsResult> {
 	};
 }
 
-export async function getStaticProps(context: {params: {partnerID: string}}): Promise<GetStaticPropsResult<any>> {
+export async function getStaticProps(context: {params: {partnerID: string}}): Promise<GetStaticPropsResult<{partnerID: string}>>{
 	return ({props: {partnerID: context.params.partnerID}});
 }
 


### PR DESCRIPTION
## Description

The purpose to this pull request is to fix a type warning present in the repo.

After executing `yarn lint` you can observe the following warning in the terminal:

⚠️ Unexpected any. Specify a different type

To resolve this warning, I replaced existing any type with more specific type. 

## Motivation and Context

The motivation is fix current warning and avoid code inconsistencies.

## How Has This Been Tested?

I confirmed that the warning was no longer present after making the change.