### PR TITLE
fix: Resolve dashboard crash + UI fixes

### DIFF
--- a/components/charts/Chart.tsx
+++ b/components/charts/Chart.tsx
@@ -11,6 +11,8 @@ import type {TChartProps} from '../../types/chart';
 function Chart(props: TChartProps): ReactElement {
 	const {type, data} = props; 
 
+	const isLegendShown = data.length > 0 && data[0].name !== 'no data';
+	
 	// function chartNavigation(): void {
 	// 	alert('Feature currently unavailable');
 	// }
@@ -32,9 +34,17 @@ function Chart(props: TChartProps): ReactElement {
 
 				{type === 'composed' && <Composed {...props} />}
 
-				{type === 'stacked' && <Stacked {...props} />}
-
-				{data.length > 0 && <ChartLegend items={props.legendItems}/> }
+				{type === 'stacked' && (data[0].name !== 'no data' ?
+					<Stacked {...props} /> :
+					<div className={'flex h-full w-[85%] items-center justify-center bg-[#E1E1E1]'}>
+						<div className={'text-center'}>
+							<h1 className={'mb-2'}>{'Nothing to see here...'}</h1>
+							<p>{'Your vaults haven\'t earned any payouts yet. Check back later!'}</p>
+						</div>
+					</div>
+				)}
+				
+				{isLegendShown && <ChartLegend items={props.legendItems}/> }
 			</div>
 
 			{/* {data.length > 0 && 

--- a/components/dashboard/DashboardTabsWrapper.tsx
+++ b/components/dashboard/DashboardTabsWrapper.tsx
@@ -191,7 +191,7 @@ function	DashboardTabsWrapper(props: {partnerID: string}): ReactElement {
 									const missingData = [];
 
 									if(data.ts > earliestTimestamp){
-										const numToAdd = (data.ts - earliestTimestamp) / 86400;
+										const numToAdd = Math.floor((data.ts - earliestTimestamp) / 86400);
 
 										for (let i = 0; i < numToAdd; i++) {
 											const ts = earliestTimestamp + (86400 * i);
@@ -268,7 +268,7 @@ function	DashboardTabsWrapper(props: {partnerID: string}): ReactElement {
 									const missingData = [];
 
 									if(data.ts > earliestTimestamp){
-										const numToAdd = (data.ts - earliestTimestamp) / 86400;
+										const numToAdd = Math.floor((data.ts - earliestTimestamp) / 86400);
 										for (let i = 0; i < numToAdd; i++) {
 											const ts = earliestTimestamp + (86400 * i);
 											const _date = unix(ts).format('MMM DD YYYY');

--- a/components/dashboard/DashboardTabsWrapper.tsx
+++ b/components/dashboard/DashboardTabsWrapper.tsx
@@ -29,7 +29,7 @@ const dataWindows = [
 	{name: '1 week', value: 7},
 	{name: '1 month', value: 29},
 	{name: '1 year', value: 365},
-	{name: 'All time', value: 40}
+	{name: 'All time', value: 45}
 ];
 
 type TProps = {

--- a/components/dashboard/SummaryMetrics.tsx
+++ b/components/dashboard/SummaryMetrics.tsx
@@ -54,7 +54,7 @@ function SummaryMetrics(props: TProps): ReactElement {
 				</div>
 			</div>
 
-			<div className={'my-20 flex w-[60%] justify-between bg-good-ol-grey-100 md:hidden'}>
+			<div className={'my-10 grid grid-cols-2 bg-good-ol-grey-100 md:hidden'}>
 				<div>
 					<div className={'mb-5'}>
 						<p>{'TVL'}</p>
@@ -72,14 +72,14 @@ function SummaryMetrics(props: TProps): ReactElement {
 				</div>
 
 				<div>
-					<div className={'mb-5'}>
+					<div className={'mb-5 ml-8'}>
 						<p>{'Annual Yield'}</p>
 						<b className={'text-2xl tabular-nums'}>
 							{vault ? formatPercent(props.vault.apy) : '-'}
 						</b>
 					</div>
 
-					<div>
+					<div className={'ml-8'}>
 						<p>{'Risk Score'}</p>
 						<b className={'text-2xl tabular-nums'}>
 							{vault ? formatAmount(props.vault.riskScore, 0, 2) : '-'}

--- a/components/graphs/OverviewChart.tsx
+++ b/components/graphs/OverviewChart.tsx
@@ -104,45 +104,37 @@ function	OverviewChart(props: TOverviewChartProps): ReactElement {
 	
 	return (
 		<div>
-			{harvestEvents[0].name === 'no data' ? (
-				<div className={'flex h-full w-[85%] items-center justify-center bg-[#E1E1E1]'}>
-					<div className={'text-center'}>
-						<h1 className={'mb-2'}>{'Nothing to see here...'}</h1>
-						<p>{'Your vaults haven\'t earned any payouts yet. Check back later!'}</p>
-					</div>
-				</div>
-			) : (
-				<Chart
-					title={'Individual Harvest Events (USD)'}
-					type={'stacked'}
-					className={'mb-20'}
-					windowValue={windowValue}
-					data={harvestEvents}
-					bars={assetsList.map((asset, idx): {name: string, fill: string} => {
-						const bar = {name: `data.${asset}`, fill: chartColors[idx % chartColors.length]};
-						return bar;
-					})}
-					yAxisOptions={{domain: [0, 'auto'], hideRightAxis: true}}
-					xAxisOptions={{interval: undefined}}
-					tooltipItems={assetsList.map((asset, idx): TTooltipItem => {
-						const [name, network] = asset.split('_');
-						const networkShort = NETWORK_LABELS[+network];
-						const fill = chartColors[idx % chartColors.length];
+			<Chart
+				title={'Individual Harvest Events (USD)'}
+				type={'stacked'}
+				className={'mb-20'}
+				windowValue={windowValue}
+				data={harvestEvents}
+				bars={assetsList.map((asset, idx): {name: string, fill: string} => {
+					const bar = {name: `data.${asset}`, fill: chartColors[idx % chartColors.length]};
+					return bar;
+				})}
+				yAxisOptions={{domain: [0, 'auto'], hideRightAxis: true}}
+				xAxisOptions={{interval: undefined}}
+				tooltipItems={assetsList.map((asset, idx): TTooltipItem => {
+					const [name, network] = asset.split('_');
+					const networkShort = NETWORK_LABELS[+network];
+					const fill = chartColors[idx % chartColors.length];
 						
-						return {name: `${name} - ${networkShort}`, symbol: {pre: '$', post: ''}, fill};
-					}).reverse()}
-					legendItems={assetsList.map((asset, idx): TLegendItem => {
-						const [token, ,] = asset.split('_');
+					return {name: `${name} - ${networkShort}`, symbol: {pre: '$', post: ''}, fill};
+				}).reverse()}
+				legendItems={assetsList.map((asset, idx): TLegendItem => {
+					const [token, ,] = asset.split('_');
 		
-						const legendItem = {
-							type: 'single',
-							details: `${token}`,
-							color: chartColors[idx % chartColors.length],
-							isCondensed: true
-						};
-						return legendItem;
-					}).reverse()} />
-			)}
+					const legendItem = {
+						type: 'single',
+						details: `${token}`,
+						color: chartColors[idx % chartColors.length],
+						isCondensed: true
+					};
+					return legendItem;
+				}).reverse()} />
+
 	
 
 			<Chart

--- a/hooks/useWindowDimensions.tsx
+++ b/hooks/useWindowDimensions.tsx
@@ -18,9 +18,11 @@ function getWindowDimensions(): TWindowDimensions {
 }
 
 export default function useWindowDimensions(): TWindowDimensions {
-	const [windowDimensions, set_windowDimensions] = useState(getWindowDimensions());
+	const [windowDimensions, set_windowDimensions] = useState({width: 0, height: 0});
 
 	useEffect((): TVoidCleanupFunction => {
+		set_windowDimensions(getWindowDimensions());
+
 		function handleResize(): void {
 			set_windowDimensions(getWindowDimensions());
 		}

--- a/pages/dashboard/[partnerID].tsx
+++ b/pages/dashboard/[partnerID].tsx
@@ -4,6 +4,7 @@ import router from 'next/router';
 import {DashboardTabsWrapper} from 'components/dashboard/DashboardTabsWrapper';
 import {useAuth} from 'contexts/useAuth';
 import {PartnerContextApp, usePartner} from 'contexts/usePartner';
+import useWindowDimensions from 'hooks/useWindowDimensions';
 import {LOGOS, PARTNERS} from 'utils/b2b/Partners';
 import {Button} from '@yearn-finance/web-lib/components/Button';
 
@@ -15,6 +16,7 @@ function formatDate(date: Date): string {
 }
 
 function Index({partnerID}: {partnerID: string}): ReactElement {
+	const {width} = useWindowDimensions();
 	const currentDate = new Date();
 	const currentYear = currentDate.getFullYear();
 	const lastMonth = currentDate.getMonth() - 1;
@@ -79,13 +81,18 @@ function Index({partnerID}: {partnerID: string}): ReactElement {
 
 	return (
 		<main className={'mb-20 pb-20'}>
-			<section aria-label={'hero'} className={'mt-[75px] mb-14 grid grid-cols-12'}>
-				<div className={'col-span-12 md:col-span-7'}>
-					<h1 className={'mb-2 text-6xl text-neutral-900 md:text-8xl'}>
+			<section aria-label={'hero'} className={'mt-3 mb-8 grid grid-cols-8 md:mb-14 md:mt-[75px] md:grid-cols-12'}>
+
+				<div className={'col-span-3 md:hidden'}>
+					{ width < 768 && LOGOS[currentPartnerName]}
+				</div>
+
+				<div className={'col-span-8 lg:col-span-9'}>
+					<h1 className={'my-4 text-6xl text-neutral-900 md:text-8xl'}>
 						{currentPartner?.name === 'Abracadabra.Money' ? 'Abracadabra': currentPartner?.name}
 					</h1>
 
-					<p className={'mb-10 w-3/4 text-neutral-500'}>{`Last updated ${lastSync}`}</p>
+					<p className={'mb-6 w-3/4 text-neutral-500 md:mb-10'}>{`Last updated ${lastSync}`}</p>
 
 					<form onSubmit={downloadReport}>
 						<div className={'mt-2 flex flex-row justify-start sm:items-end'}>
@@ -129,13 +136,10 @@ function Index({partnerID}: {partnerID: string}): ReactElement {
 					</form>
 				</div>
 
-				<div className={'col-span-1 hidden md:block'} />
-
-				<div className={'col-span-3 hidden md:block'}>
-					{LOGOS[currentPartnerName]}
+				<div className={'hidden md:col-span-4 md:block lg:col-span-3'}>
+					{ width >= 768 && LOGOS[currentPartnerName]}
 				</div>
 
-				<div className={'col-span-2 hidden md:block'} />
 			</section>
 
 			<section aria-label={'tabs'}>

--- a/pages/dashboard/[partnerID].tsx
+++ b/pages/dashboard/[partnerID].tsx
@@ -88,8 +88,8 @@ function Index({partnerID}: {partnerID: string}): ReactElement {
 					<p className={'mb-10 w-3/4 text-neutral-500'}>{`Last updated ${lastSync}`}</p>
 
 					<form onSubmit={downloadReport}>
-						<div className={'mt-2 flex flex-row items-end space-x-4'}>
-							<div>
+						<div className={'mt-2 flex flex-row justify-start sm:items-end'}>
+							<div className={'pr-4'}>
 								<label className={'block text-neutral-500'} htmlFor={'start'}>{'From'}</label>
 								<input
 									className={'text-neutral-500'}
@@ -102,7 +102,7 @@ function Index({partnerID}: {partnerID: string}): ReactElement {
 									max={reportEnd} />
 							</div>
 
-							<div>
+							<div className={'pr-4'}>
 								<label className={'block text-neutral-500'} htmlFor={'end'}>{'To'}</label>
 								<input
 									className={'text-neutral-500'}
@@ -116,11 +116,16 @@ function Index({partnerID}: {partnerID: string}): ReactElement {
 							</div>
 
 							<Button
-								className={'w-[200px] text-sm  md:text-base'}
+								className={'hidden w-[200px] text-sm sm:block lg:text-base'}
 								variant={'filled'}>
 								{'Download Report'}
 							</Button>
 						</div>
+						<Button
+							className={'my-4 w-[100%]  sm:hidden'}
+							variant={'filled'}>
+							{'Download Report'}
+						</Button>
 					</form>
 				</div>
 


### PR DESCRIPTION
## Description

This PR resolves an error that caused a small subset of dashboards to crash during data visualization. The issue itself was related to how I was back-filling missing data (which is require to avoid other visual issues). 

Basically the calculation for how many days of empty data needed to be back-filled could in some cases result in a decimal (ex: 28.1234) number causing an extra incorrect day to be added to the back-filled data, leading to out of range errors during visualization. 

This error is resolve by using Math.floor in DashboardTabsWrapper.tsx, on lines 194 and 271

Extra: 
- Improved UI when stacked charts have no data to display (Phuture is an example). We show show chart title to give user context for what chart lacks data currently. 
- Expanded All time data window to 45 form 40 (these are current limitations imposed by exporter until it is made bi-directional)

Extra from Itzabelli (I reviewed / approved):
- https://github.com/yearn/b2b-dashboard/pull/154
- https://github.com/yearn/b2b-dashboard/pull/153
- https://github.com/yearn/b2b-dashboard/pull/152


## Related Issue

N/A

## Motivation and Context

Resolve dashboard crash

## How Has This Been Tested?

I manually entered all dashboards to verify the overview tabs loaded properly 

## Resources

Following is for the improvements to the no data UI on sacked charts

Before:

<img width="1440" alt="before" src="https://user-images.githubusercontent.com/95051992/226106611-fc12e57d-372c-477d-9572-01bf2e3d02c1.png">

After: 

<img width="1297" alt="after" src="https://user-images.githubusercontent.com/95051992/226106562-18cf564d-c05d-44d5-b869-845d84d913a7.png">
