### PR TITLE
fix: Add logos for partner dashboard on mobile

### DIFF
--- a/hooks/useWindowDimensions.tsx
+++ b/hooks/useWindowDimensions.tsx
@@ -21,6 +21,8 @@ export default function useWindowDimensions(): TWindowDimensions {
 	const [windowDimensions, set_windowDimensions] = useState({width: 0, height: 0});
 
 	useEffect((): TVoidCleanupFunction => {
+		set_windowDimensions(getWindowDimensions());
+
 		function handleResize(): void {
 			set_windowDimensions(getWindowDimensions());
 		}

--- a/hooks/useWindowDimensions.tsx
+++ b/hooks/useWindowDimensions.tsx
@@ -18,7 +18,7 @@ function getWindowDimensions(): TWindowDimensions {
 }
 
 export default function useWindowDimensions(): TWindowDimensions {
-	const [windowDimensions, set_windowDimensions] = useState(getWindowDimensions());
+	const [windowDimensions, set_windowDimensions] = useState({width: 0, height: 0});
 
 	useEffect((): TVoidCleanupFunction => {
 		function handleResize(): void {

--- a/pages/dashboard/[partnerID].tsx
+++ b/pages/dashboard/[partnerID].tsx
@@ -79,13 +79,18 @@ function Index({partnerID}: {partnerID: string}): ReactElement {
 
 	return (
 		<main className={'mb-20 pb-20'}>
-			<section aria-label={'hero'} className={'mt-[75px] mb-14 grid grid-cols-12'}>
-				<div className={'col-span-12 md:col-span-7'}>
-					<h1 className={'mb-2 text-6xl text-neutral-900 md:text-8xl'}>
+			<section aria-label={'hero'} className={'mt-3 mb-8 grid grid-cols-8 md:mb-14 md:mt-[75px] md:grid-cols-12'}>
+
+				<div className={'col-span-3 md:hidden'}>
+					{LOGOS[currentPartnerName]}
+				</div>
+
+				<div className={'col-span-8 lg:col-span-9'}>
+					<h1 className={'my-4 text-6xl text-neutral-900 md:text-8xl'}>
 						{currentPartner?.name === 'Abracadabra.Money' ? 'Abracadabra': currentPartner?.name}
 					</h1>
 
-					<p className={'mb-10 w-3/4 text-neutral-500'}>{`Last updated ${lastSync}`}</p>
+					<p className={'mb-6 w-3/4 text-neutral-500 md:mb-10'}>{`Last updated ${lastSync}`}</p>
 
 					<form onSubmit={downloadReport}>
 						<div className={'mt-2 flex flex-row items-end space-x-4'}>
@@ -124,13 +129,10 @@ function Index({partnerID}: {partnerID: string}): ReactElement {
 					</form>
 				</div>
 
-				<div className={'col-span-1 hidden md:block'} />
-
-				<div className={'col-span-3 hidden md:block'}>
+				<div className={'hidden md:col-span-4 md:block lg:col-span-3'}>
 					{LOGOS[currentPartnerName]}
 				</div>
 
-				<div className={'col-span-2 hidden md:block'} />
 			</section>
 
 			<section aria-label={'tabs'}>

--- a/pages/dashboard/[partnerID].tsx
+++ b/pages/dashboard/[partnerID].tsx
@@ -4,6 +4,7 @@ import router from 'next/router';
 import {DashboardTabsWrapper} from 'components/dashboard/DashboardTabsWrapper';
 import {useAuth} from 'contexts/useAuth';
 import {PartnerContextApp, usePartner} from 'contexts/usePartner';
+import useWindowDimensions from 'hooks/useWindowDimensions';
 import {LOGOS, PARTNERS} from 'utils/b2b/Partners';
 import {Button} from '@yearn-finance/web-lib/components/Button';
 
@@ -15,6 +16,7 @@ function formatDate(date: Date): string {
 }
 
 function Index({partnerID}: {partnerID: string}): ReactElement {
+	const {width} = useWindowDimensions();
 	const currentDate = new Date();
 	const currentYear = currentDate.getFullYear();
 	const lastMonth = currentDate.getMonth() - 1;
@@ -82,7 +84,7 @@ function Index({partnerID}: {partnerID: string}): ReactElement {
 			<section aria-label={'hero'} className={'mt-3 mb-8 grid grid-cols-8 md:mb-14 md:mt-[75px] md:grid-cols-12'}>
 
 				<div className={'col-span-3 md:hidden'}>
-					{LOGOS[currentPartnerName]}
+					{ width < 768 && LOGOS[currentPartnerName]}
 				</div>
 
 				<div className={'col-span-8 lg:col-span-9'}>
@@ -130,7 +132,7 @@ function Index({partnerID}: {partnerID: string}): ReactElement {
 				</div>
 
 				<div className={'hidden md:col-span-4 md:block lg:col-span-3'}>
-					{LOGOS[currentPartnerName]}
+					{ width >= 768 && LOGOS[currentPartnerName]}
 				</div>
 
 			</section>


### PR DESCRIPTION
## Description

The purpose to this pull request is to include logos on the partner dashboard as suggested by the team.

## Related Issue

resolves #150

## Motivation and Context

The motivation is to fix the current issue and improve the appearance (on mobile) of the partner pages.

## How Has This Been Tested?

After making the changes I ran `yarn dev` and confirmed that everything appeared as expected

## Resources

<img width="386" alt="dashboard-partner-on-mobile" src="https://user-images.githubusercontent.com/104786213/226173411-100e6bb8-a930-491b-92a2-38d559c10d56.png">
