### PR TITLE
fix: Apply media queries to dashboard section

### DIFF
--- a/pages/dashboard/[partnerID].tsx
+++ b/pages/dashboard/[partnerID].tsx
@@ -88,7 +88,7 @@ function Index({partnerID}: {partnerID: string}): ReactElement {
 					<p className={'mb-10 w-3/4 text-neutral-500'}>{`Last updated ${lastSync}`}</p>
 
 					<form onSubmit={downloadReport}>
-						<div className={'mt-2 flex flex-wrap items-end justify-start space-y-4 md:flex-row'}>
+						<div className={'mt-2 flex flex-row justify-start sm:items-end'}>
 							<div className={'pr-4'}>
 								<label className={'block text-neutral-500'} htmlFor={'start'}>{'From'}</label>
 								<input
@@ -116,11 +116,16 @@ function Index({partnerID}: {partnerID: string}): ReactElement {
 							</div>
 
 							<Button
-								className={'ml-0 mb-px w-[160px] text-sm min-[830px]:w-[180px] min-[830px]:text-base'}
+								className={'hidden w-[200px] text-sm sm:block lg:text-base'}
 								variant={'filled'}>
 								{'Download Report'}
 							</Button>
 						</div>
+						<Button
+							className={'my-4 w-[100%]  sm:hidden'}
+							variant={'filled'}>
+							{'Download Report'}
+						</Button>
 					</form>
 				</div>
 

--- a/pages/dashboard/[partnerID].tsx
+++ b/pages/dashboard/[partnerID].tsx
@@ -88,8 +88,8 @@ function Index({partnerID}: {partnerID: string}): ReactElement {
 					<p className={'mb-10 w-3/4 text-neutral-500'}>{`Last updated ${lastSync}`}</p>
 
 					<form onSubmit={downloadReport}>
-						<div className={'mt-2 flex flex-row items-end space-x-4'}>
-							<div>
+						<div className={'mt-2 flex flex-wrap items-end justify-start space-y-4 md:flex-row'}>
+							<div className={'pr-4'}>
 								<label className={'block text-neutral-500'} htmlFor={'start'}>{'From'}</label>
 								<input
 									className={'text-neutral-500'}
@@ -102,7 +102,7 @@ function Index({partnerID}: {partnerID: string}): ReactElement {
 									max={reportEnd} />
 							</div>
 
-							<div>
+							<div className={'pr-4'}>
 								<label className={'block text-neutral-500'} htmlFor={'end'}>{'To'}</label>
 								<input
 									className={'text-neutral-500'}
@@ -116,7 +116,7 @@ function Index({partnerID}: {partnerID: string}): ReactElement {
 							</div>
 
 							<Button
-								className={'w-[200px] text-sm  md:text-base'}
+								className={'ml-0 mb-px w-[160px] text-sm min-[830px]:w-[180px] min-[830px]:text-base'}
 								variant={'filled'}>
 								{'Download Report'}
 							</Button>


### PR DESCRIPTION
## Description

The section that contains the range of dates and the 'Download Report' button is overflowing when the available screen size decreases. To address this I applied media queries to improve appearance and the user experience on different screen sizes. 

I decided kept the components lined up on the left side and equal in length. However, the other option is to adjust the size of the all components and center them. Let me know if this last option is better or if you have a guide image of how this section should look on mobile.

## Related Issue

resolves #148

## Motivation and Context

The intention after applying media queries is to improve the appearance of this section. Currently no responsive styles are applied to this section leading to overflow on small screens.

## How Has This Been Tested?

After making the changes I ran `yarn dev` and confirmed that everything appeared as expected

## Resources (if appropriate):

<img width="386" alt="Range-date-report" src="https://user-images.githubusercontent.com/104786213/226173527-91039601-be8a-4012-b013-ca043ef187d9.png">
