### PR TITLE
style: Improve dashboard section on mobile

### DIFF
--- a/pages/dashboard/[partnerID].tsx
+++ b/pages/dashboard/[partnerID].tsx
@@ -95,44 +95,41 @@ function Index({partnerID}: {partnerID: string}): ReactElement {
 					<p className={'mb-6 w-3/4 text-neutral-500 md:mb-10'}>{`Last updated ${lastSync}`}</p>
 
 					<form onSubmit={downloadReport}>
-						<div className={'mt-2 flex flex-row justify-start sm:items-end'}>
-							<div className={'pr-4'}>
-								<label className={'block text-neutral-500'} htmlFor={'start'}>{'From'}</label>
-								<input
-									className={'text-neutral-500'}
-									type={'date'}
-									id={'start'}
-									name={'range-start'}
-									value={reportStart}
-									onChange={handleReportDateChange}
-									min={'2021-01-01'}
-									max={reportEnd} />
-							</div>
+						<div className={'mt-2 grid-cols-1 items-end space-y-4 md:flex md:flex-row md:justify-start'}>
+							<div className={'grid grid-cols-2'} >
+								<div className={'grid grid-rows-2 items-end md:w-[170px] md:pr-4 lg:w-[180px]'}>
+									<label className={'text-neutral-500'} htmlFor={'start'}>{'From'}</label>
+									<input
+										className={'text-neutral-500'}
+										type={'date'}
+										id={'start'}
+										name={'range-start'}
+										value={reportStart}
+										onChange={handleReportDateChange}
+										min={'2021-01-01'}
+										max={reportEnd} />
+								</div>
 
-							<div className={'pr-4'}>
-								<label className={'block text-neutral-500'} htmlFor={'end'}>{'To'}</label>
-								<input
-									className={'text-neutral-500'}
-									type={'date'}
-									id={'end'}
-									name={'range-end'}
-									value={reportEnd}
-									onChange={handleReportDateChange}
-									min={'2021-01-01'}
-									max={today} />
+								<div className={'grid grid-rows-2 items-end md:w-[170px] md:pr-4 lg:w-[180px]'}>
+									<label className={'text-neutral-500'} htmlFor={'end'}>{'To'}</label>
+									<input
+										className={'text-neutral-500'}
+										type={'date'}
+										id={'end'}
+										name={'range-end'}
+										value={reportEnd}
+										onChange={handleReportDateChange}
+										min={'2021-01-01'}
+										max={today} />
+								</div>
 							</div>
 
 							<Button
-								className={'hidden w-[200px] text-sm sm:block lg:text-base'}
+								className={'w-full md:w-[180px] md:text-base lg:w-[200px]'}
 								variant={'filled'}>
 								{'Download Report'}
 							</Button>
 						</div>
-						<Button
-							className={'my-4 w-[100%]  sm:hidden'}
-							variant={'filled'}>
-							{'Download Report'}
-						</Button>
 					</form>
 				</div>
 


### PR DESCRIPTION
## Description

This PR intends to improve the previous proposal made on this section. Currently, some components are aligned on the left (range of date buttons), while other occupies the total width ('Download report' button). 

The changes suggested making match the size of all components and they use all the available width when the user visit the page from mobile devices. This fit remove the small empty space between one and other line, which I think improve the appearance of this section.

## Motivation and Context

The intention after applying this change is to making that this section looks better on mobile version. 

## How Has This Been Tested?

After making the changes I ran `yarn dev` and confirmed that everything appeared as expected

## Resources (if appropriate):
Image on the left show before, image on the right shows after
<img width="1246" alt="Screenshot 2023-03-22 at 3 52 52 PM" src="https://user-images.githubusercontent.com/104786213/226914108-77b93dd6-074c-46d6-9a52-21b0cbad8cfe.png">


