### PR TITLE
fix: Resolve tab selection causing unintended layout shift

### DIFF
--- a/components/dashboard/DashboardTabsWrapper.tsx
+++ b/components/dashboard/DashboardTabsWrapper.tsx
@@ -61,6 +61,7 @@ function	Tabs({selectedIndex, set_selectedIndex}: TProps): ReactElement {
 						onClick={(): void => set_selectedIndex(idx)}>
 						<p
 							aria-selected={selectedIndex === idx}
+							title={`${vault.token} - ${NETWORK_LABELS[vault.chainID]}`}
 							className={'hover-fix tab'}>
 							{`${vault.token} - ${NETWORK_LABELS[vault.chainID]}`}
 						</p>


### PR DESCRIPTION
## Description

This PR resolves a small layout shift that was caused when selecting tabs on the dashboard. It looks like the CSS styles to avoid this were present but the `title` attribute had been removed from the `<p>` tag wrapping the title (by me lol) as I didn't see what benefit it had. I understand now and will leave it alone :) 

## Related Issue

resolves #147 

## Motivation and Context

Improve UX

## How Has This Been Tested?

Manually clicking tabs after making the change to ensure the shift was no longer present

## Resources
N/A