### PR TITLE
feat: Make partner dashboard URLs shareable

### DIFF
--- a/components/dashboard/DashboardTabsWrapper.tsx
+++ b/components/dashboard/DashboardTabsWrapper.tsx
@@ -122,8 +122,7 @@ function	Tabs({selectedIndex, set_selectedIndex}: TProps): ReactElement {
 	);
 }
 
-function	DashboardTabsWrapper(props: {partnerID: string}): ReactElement {
-	const {partnerID} = props;
+function	DashboardTabsWrapper({partnerID}: {partnerID: string}): ReactElement {
 	const {vaults} = usePartner();
 	const [selectedIndex, set_selectedIndex] = useState(-1);
 	const [activeWindow, set_activeWindow] = useState('1 month');

--- a/components/dashboard/DashboardTabsWrapper.tsx
+++ b/components/dashboard/DashboardTabsWrapper.tsx
@@ -130,6 +130,7 @@ function	DashboardTabsWrapper({partnerID}: {partnerID: string}): ReactElement {
 	const [balanceTVLs, set_balanceTVLs] = useState<TDict<TChartBar[]>>();
 	const [wrapperTotals, set_wrapperTotals] = useState<TChartBar[]>();
 	const [payoutTotals, set_payoutTotals] = useState<TDict<TChartBar[]>>();
+	const [aggregationStep, set_aggregationStep] = useState(0);
 
 	const selectedVault = Object.values(vaults)[selectedIndex];
 
@@ -240,6 +241,7 @@ function	DashboardTabsWrapper({partnerID}: {partnerID: string}): ReactElement {
 
 				set_balanceTVLs(partnerBalanceTVL);
 				set_wrapperTotals(wrapperData);
+				set_aggregationStep((prevStep): number => (prevStep + 1));
 			});
 
 			
@@ -289,9 +291,17 @@ function	DashboardTabsWrapper({partnerID}: {partnerID: string}): ReactElement {
 				});
 
 				set_payoutTotals(partnerPayoutTotals);
+				set_aggregationStep((prevStep): number => (prevStep + 1));
 			});
 
-	}, [partnerID, windowValue]);
+	}, [partnerID, set_aggregationStep, windowValue]);
+
+
+	if (aggregationStep === 2 && Object.values(balanceTVLs || []).length === 0) {
+		return (
+			<h1>{'No Vaults Found'}</h1>
+		);
+	}
 
 	return (
 		<div aria-label={'Vault Details'} className={'col-span-12 mb-4 flex flex-col bg-neutral-100'}>
@@ -340,7 +350,7 @@ function	DashboardTabsWrapper({partnerID}: {partnerID: string}): ReactElement {
 				vault={selectedVault}
 				selectedIndex={selectedIndex}/>
 
-			{ !balanceTVLs || !wrapperTotals || !payoutTotals ? 
+			{aggregationStep < 2 || !balanceTVLs || !wrapperTotals || !payoutTotals ? 
 				<h1>{'Generating visuals...'}</h1> : (
 					<>			
 						{Object.values(vaults || []).map((_, idx): ReactElement | null => {

--- a/contexts/usePartner.tsx
+++ b/contexts/usePartner.tsx
@@ -1,7 +1,7 @@
 import	React, {createContext, useContext, useMemo}	from 'react';
 import {useYearn} from 'contexts/useYearn';
 import {NETWORK_CHAINID} from 'utils/b2b';
-import {SHAREABLE_ADDRESSES} from 'utils/b2b/Partners';
+import {PARTNERS, SHAREABLE_ADDRESSES} from 'utils/b2b/Partners';
 import useSWR from 'swr';
 import {isZeroAddress, toAddress} from '@yearn-finance/web-lib/utils/address';
 import {baseFetcher} from '@yearn-finance/web-lib/utils/fetchers';
@@ -29,16 +29,17 @@ export const PartnerContextApp = ({
 }: {partnerID: string, children: ReactElement}): ReactElement => {
 	const	{vaults: yVaults} = useYearn();
 	const isShareableURL = !isZeroAddress(toAddress(partnerID));
-	const id = isShareableURL ? SHAREABLE_ADDRESSES[partnerID].shortName : partnerID;
+	const currentPartner = isShareableURL ? SHAREABLE_ADDRESSES[partnerID] : PARTNERS[partnerID];
+	const currentPartnerShortname = currentPartner ? currentPartner.shortName : '';
 
 	const	{data: balances, isLoading: isLoadingBalances} = useSWR(
-		`${process.env.YVISION_BASE_URI}/partners/${id}/balance`,
+		`${process.env.YVISION_BASE_URI}/partners/${currentPartnerShortname}/balance`,
 		baseFetcher,
 		{revalidateOnFocus: false}
 	) as SWRResponse;
 	
 	const	{data: payouts, isLoading: isLoadingPayouts} = useSWR(
-		`${process.env.YVISION_BASE_URI}/partners/${id}/payout_total`,
+		`${process.env.YVISION_BASE_URI}/partners/${currentPartnerShortname}/payout_total`,
 		baseFetcher,
 		{revalidateOnFocus: false}
 	) as SWRResponse;

--- a/contexts/usePartner.tsx
+++ b/contexts/usePartner.tsx
@@ -1,8 +1,9 @@
 import	React, {createContext, useContext, useMemo}	from 'react';
 import {useYearn} from 'contexts/useYearn';
 import {NETWORK_CHAINID} from 'utils/b2b';
+import {SHAREABLE_ADDRESSES} from 'utils/b2b/Partners';
 import useSWR from 'swr';
-import {toAddress} from '@yearn-finance/web-lib/utils/address';
+import {isZeroAddress, toAddress} from '@yearn-finance/web-lib/utils/address';
 import {baseFetcher} from '@yearn-finance/web-lib/utils/fetchers';
 
 import type {ReactElement} from 'react';
@@ -27,15 +28,17 @@ export const PartnerContextApp = ({
 	children
 }: {partnerID: string, children: ReactElement}): ReactElement => {
 	const	{vaults: yVaults} = useYearn();
+	const isShareableURL = !isZeroAddress(toAddress(partnerID));
+	const id = isShareableURL ? SHAREABLE_ADDRESSES[partnerID].shortName : partnerID;
 
 	const	{data: balances, isLoading: isLoadingBalances} = useSWR(
-		`${process.env.YVISION_BASE_URI}/partners/${partnerID}/balance`,
+		`${process.env.YVISION_BASE_URI}/partners/${id}/balance`,
 		baseFetcher,
 		{revalidateOnFocus: false}
 	) as SWRResponse;
 	
 	const	{data: payouts, isLoading: isLoadingPayouts} = useSWR(
-		`${process.env.YVISION_BASE_URI}/partners/${partnerID}/payout_total`,
+		`${process.env.YVISION_BASE_URI}/partners/${id}/payout_total`,
 		baseFetcher,
 		{revalidateOnFocus: false}
 	) as SWRResponse;

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,17 +1,17 @@
-import React, {useMemo, useState} from 'react';
+import React, {useEffect, useMemo, useState} from 'react';
 import Head from 'next/head';
 import Link from 'next/link';
 import {useRouter} from 'next/router';
 import {DefaultSeo} from 'next-seo';
 import {AuthContextApp, useAuth} from 'contexts/useAuth';
 import {YearnContextApp} from 'contexts/useYearn';
-import {PARTNERS} from 'utils/b2b/Partners';
+import {PARTNERS, SHAREABLE_ADDRESSES} from 'utils/b2b/Partners';
 import {Button} from '@yearn-finance/web-lib/components/Button';
 import {Card} from '@yearn-finance/web-lib/components/Card';
 import {Modal} from '@yearn-finance/web-lib/components/Modal';
 import {yToast} from '@yearn-finance/web-lib/components/yToast';
 import {WithYearn} from '@yearn-finance/web-lib/contexts/WithYearn';
-import {toAddress} from '@yearn-finance/web-lib/utils/address';
+import {isZeroAddress, toAddress} from '@yearn-finance/web-lib/utils/address';
 
 import type {AppProps} from 'next/app';
 import type {ReactElement} from 'react';
@@ -97,6 +97,17 @@ function	AppHeader(): ReactElement {
 	const	{hasModal, isLoggedIn, isLoading, set_hasModal, set_isLoggedIn, set_isLoading} = useAuth();
 	const	[authOption, set_authOption] = useState('Log in');
 	const	[address, set_address] = useState('');
+
+	const slug = router.query.partnerID as string;
+
+	useEffect((): void => {
+		if(slug && !isZeroAddress(toAddress(slug)) && SHAREABLE_ADDRESSES[slug]){
+			set_address('shareable');
+			set_isLoggedIn(true);
+			set_authOption('Log out');
+		}
+
+	}, [set_isLoggedIn, slug]);
 
 	return (
 		<header>

--- a/pages/dashboard/[partnerID].tsx
+++ b/pages/dashboard/[partnerID].tsx
@@ -25,7 +25,7 @@ function Index({partnerID}: {partnerID: string}): ReactElement {
 	const firstDayLastMonth = formatDate(new Date(new Date().setFullYear(currentYear, lastMonth, 1)));
 
 	const {isLoggedIn} = useAuth();
-	const {isLoadingVaults, vaults} = usePartner();
+	const {isLoadingVaults} = usePartner();
 	const [lastSync, set_lastSync] = useState('');
 	const [reportStart, set_reportStart] = useState(firstDayLastMonth);
 	const [reportEnd, set_reportEnd] = useState(today);
@@ -71,16 +71,10 @@ function Index({partnerID}: {partnerID: string}): ReactElement {
 			);
 		}
 
-		if (currentPartner && !isLoadingVaults && Object.values(vaults || []).length === 0) {
-			return (
-				<h1>{'No Vaults Found'}</h1>
-			);
-		}
-
 		return (
 			<DashboardTabsWrapper partnerID={currentPartnerShortname} />
 		);
-	}, [currentPartner, isLoadingVaults, vaults, currentPartnerShortname]);
+	}, [currentPartner, isLoadingVaults, currentPartnerShortname]);
 
 	return (
 		<main className={'mb-20 pb-20'}>

--- a/pages/dashboard/[partnerID].tsx
+++ b/pages/dashboard/[partnerID].tsx
@@ -33,6 +33,7 @@ function Index({partnerID}: {partnerID: string}): ReactElement {
 	const isShareableURL = !isZeroAddress(toAddress(partnerID));
 	const currentPartner = isShareableURL ? SHAREABLE_ADDRESSES[partnerID] : PARTNERS[partnerID];
 	const currentPartnerName = currentPartner ? currentPartner.name : '';
+	const currentPartnerShortname = currentPartner ? currentPartner.shortName : '';
 
 	useEffect((): void => {
 		if(!isLoggedIn && !isShareableURL){
@@ -77,9 +78,9 @@ function Index({partnerID}: {partnerID: string}): ReactElement {
 		}
 
 		return (
-			<DashboardTabsWrapper partnerID={partnerID} />
+			<DashboardTabsWrapper partnerID={currentPartnerShortname} />
 		);
-	}, [currentPartner, vaults, isLoadingVaults, partnerID]);
+	}, [currentPartner, isLoadingVaults, vaults, currentPartnerShortname]);
 
 	return (
 		<main className={'mb-20 pb-20'}>

--- a/utils/b2b/Partners.tsx
+++ b/utils/b2b/Partners.tsx
@@ -175,6 +175,10 @@ const	PARTNERS: TDict<TPartner> = {
 	}
 };
 
+const SHAREABLE_ADDRESSES: {[key: string]: {name: string, shortName: string}} = {
+	'0x679016b3f8e98673f85c6f72567f22b58aa15a54':  {name: 'QiDAO', shortName: 'qidao'}
+};
+
 
 type TPartnerLogo = {
 	[key: string]: ReactElement
@@ -227,5 +231,5 @@ const PROFIT_SHARE_TEIRS: TProfitShareTier = {
 };
 
 export {
-	LOGOS, PARTNERS, PROFIT_SHARE_TEIRS
+	LOGOS, PARTNERS, PROFIT_SHARE_TEIRS, SHAREABLE_ADDRESSES
 };

--- a/utils/b2b/Partners.tsx
+++ b/utils/b2b/Partners.tsx
@@ -176,7 +176,30 @@ const	PARTNERS: TDict<TPartner> = {
 };
 
 const SHAREABLE_ADDRESSES: {[key: string]: {name: string, shortName: string}} = {
-	'0x679016b3f8e98673f85c6f72567f22b58aa15a54':  {name: 'QiDAO', shortName: 'qidao'}
+	'0x679016b3f8e98673f85c6f72567f22b58aa15a54': {name: 'QiDAO', shortName: 'qidao'},
+	'0x82eF450FB7f06E3294F2f19ed1713b255Af0f541': {name: 'Element Finance', shortName: 'element'},
+	'0xF6Bc2E3b1F939C435D9769D078a6e5048AaBD463': {name: 'SpoolFi', shortName: 'spoolfi'},
+	'0xDF2C270f610Dc35d8fFDA5B453E74db5471E126B': {name: 'Abracadabra.Money', shortName: 'abracadabra'},
+	'0x558247e365be655f9144e1a0140D793984372Ef3': {name: 'Ledger', shortName: 'ledger'},
+	'0x8392F6669292fA56123F71949B52d883aE57e225': {name: 'Alchemix Finance', shortName: 'alchemix'},
+	'0x7b065Fcb0760dF0CEA8CFd144e08554F3CeA73D1': {name: 'Gearbox', shortName: 'gearbox'},
+	'0x926dF14a23BE491164dCF93f4c468A50ef659D5B': {name: 'Inverse Finance', shortName: 'inverse'},
+	'0x066419EaEf5DE53cc5da0d8702b990c5bc7D1AB3': {name: 'Pickle Finance', shortName: 'pickle'},
+	'0x237a4d2166Eb65cB3f9fabBe55ef2eb5ed56bdb9': {name: 'Phuture', shortName: 'phuture'},
+	'0x403d41e72308b5D89a383C3F6789EDD7D3576Ee0': {name: 'Popcorn DAO', shortName: 'popcorndao'},
+	'0x4e8a7C429192bFDa8c9a1ef0f3B749d0f66657AA': {name: 'DEUS Finance DAO', shortName: 'deus'},
+	'0x520Cf70a2D0B3dfB7386A2Bc9F800321F62a5c3a': {name: 'rhino.fi', shortName: 'rhino.fi'},
+	'0x5EF7F250f74d4F11A68054AE4e150705474a6D4a': {name: 'Wido', shortName: 'wido'},
+	'0x7301C46be73bB04847576b6Af107172bF5e8388e': {name: 'BasketDAO', shortName: 'basketdao'},
+	'0x8d0C5D009b128315715388844196B85b41D9Ea30': {name: 'Frax Finance', shortName: 'frax'},
+	'0x90A48D5CF7343B08dA12E067680B4C6dbfE551Be': {name: 'ShapeShift DAO', shortName: 'shapeshiftdao'},
+	'0xa07D75aacEFd11b425AF7181958F0F85c312f143': {name: 'Ambire Wallet', shortName: 'ambire'},
+	'0xaB40A7e3cEF4AfB323cE23B6565012Ac7c76BFef': {name: 'Tempus', shortName: 'tempus'},
+	'0xC5aF91F7D10dDe118992ecf536Ed227f276EC60D': {name: 'Akropolis', shortName: 'akropolis'},
+	'0xD0A7A8B98957b9CD3cFB9c0425AbE44551158e9e': {name: 'BadgerDAO', shortName: 'badger'},
+	'0xf6A0307cb6aA05D7C19d080A0DA9B14eAB1050b7': {name: 'Mover', shortName: 'mover'},
+	'0xa1E849B1d6c2Fd31c63EEf7822e9E0632411ada7': {name: 'Beethoven X', shortName: 'beethovenx'},
+	'0xFd1D36995d76c0F75bbe4637C84C06E4A68bBB3a': {name: 'Sturdy', shortName: 'sturdy'}
 };
 
 


### PR DESCRIPTION
## Description

This PR makes it such that each partner has an additional `dashboard/[partnerID]` page generated which uses a treasury address. See SHAREABLE_ADDRESSES in `utils/b2b/Partners.tsx` to see addresses which have corresponding sharable urls.

Notes:
- concept of aggregationStep was added to ensure partner was always shown correct UI during data aggregation process without it they were being incorrectly shown 'No Vaults Found', when  data was still being aggregated. I tried multiple approaches. The one I included was the cleanest implementation that always works. (Alternatives likely possible but will require a general refactor)

## Related Issue

resolves #159 

## Motivation and Context

It was requested that more easily sharable dashboard URLs also be made available, this implementation adds an alternative to the original login approach. 

## How Has This Been Tested?

I manually entered each dashboard, also tried variations like navigating from normal login dashboard to sharable url dashboard, bookmarking pages and returning. Everything seems to work. 
